### PR TITLE
Link to drake's pkgdown site

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -25,6 +25,8 @@ Inspired by [tidytemplate](https://github.com/tidyverse/tidytemplate/) and [lock
 
 ## Examples "in the wild"
 
+* [`drake`](https://ropensci.github.io/drake/)
+
 * [`riem`](https://ropensci.github.io/riem/)
 
 * [`ropenaq`](https://ropensci.github.io/ropenaq/)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ and [lockedatapkg](https://github.com/lockedatapublished/lockedatapkg).
 
 ## Examples “in the wild”
 
+  - [`drake`](https://ropensci.github.io/drake/)
+
   - [`riem`](https://ropensci.github.io/riem/)
 
   - [`ropenaq`](https://ropensci.github.io/ropenaq/)


### PR DESCRIPTION
This PR adds `drake` to the list of packages that use `rotemplate`. Packages are listed in alphabetical order. Thanks @maelle for the pointer.