### PR TITLE
add optional mathjax

### DIFF
--- a/inst/pkgdown/templates/head.html
+++ b/inst/pkgdown/templates/head.html
@@ -61,9 +61,11 @@
 {{#yaml}}{{#noindex}}<meta name="robots" content="noindex" />{{/noindex}}{{/yaml}}
 {{#development}}{{#in_dev}}<meta name="robots" content="noindex">{{/in_dev}}{{/development}}
 
+{{#yaml}}{{#mathjax}}
 <!-- Mathjax -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js" async integrity="sha256-nlrDrBTHxJJlDDX22AS33xYI1OJHnGMDhiYMSe2U0e0=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/config/TeX-AMS-MML_HTMLorMML.js" async integrity="sha256-4zys9A4hMQmtq2EUL+JRoXc0NZi8jVJMzb8onewOaSQ=" crossorigin="anonymous"></script>
+{{/mathjax}}{{/yaml}}
 
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-462421-8"></script>


### PR DESCRIPTION
Cc @Bisaloo 

One could e.g. run

```r
template <- list(package = "rotemplate",
                 params = list(mathjax = TRUE))
pkgdown::build_site(override = list(template = template))
```
to get the mathjax stuff. By default, or if one passes `FALSE`, there's no mathjax script in the head.

Not sure we need that now that the library is loaded asynchronously.

In any case anything under template/params (in the config file, or in the `override` argument) is passed to the mustache templates.