### PR TITLE
[WIP] Use svg logo instead of png

### DIFF
--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -1,5 +1,5 @@
 <div style="margin-top:-9px">
-  <p>{{#yaml}}{{{footer}}}{{^footer}}{{#package}}{{name}}{{/package}} is a part of <img src='https://github.com/ropensci/logos/raw/master/icon_lettering_color.png' height=40 alt = 'rOpenSci'>. Learn more at <a href="https://ropensci.org">ropensci.org</a>.{{/footer}}{{/yaml}}</p>
+  <p>{{#yaml}}{{{footer}}}{{^footer}}{{#package}}{{name}}{{/package}} is a part of <img src='https://github.com/ropensci/logos/raw/master/icon_lettering_color.svg' height=40 alt = 'rOpenSci'>. Learn more at <a href="https://ropensci.org">ropensci.org</a>.{{/footer}}{{/yaml}}</p>
 </div>
 
 <div class="author">


### PR DESCRIPTION
In addition to being vectorized, the svg version is also much lighter (10.1kB vs 204.4kB)

It would be great if the same could be done for the hexlogo but I couldn't find the `svg` source.