### PR TITLE
Use svg file for navbar hexlogo

### DIFF
--- a/inst/pkgdown/assets/ropensci.css
+++ b/inst/pkgdown/assets/ropensci.css
@@ -120,7 +120,8 @@ a:focus, a:hover {
   height: 40px;
   float: left;
   margin: 5px;
-  margin-right: 10px;
+  margin-left: 15px;
+  margin-right: 15px;
 }
 
 @media screen and (min-width: 768px) {

--- a/inst/pkgdown/assets/ropensci.css
+++ b/inst/pkgdown/assets/ropensci.css
@@ -117,15 +117,15 @@ a:focus, a:hover {
 }
 
 #hexlogo {
-  height: 50px;
+  height: 40px;
   float: left;
+  margin: 5px;
   margin-right: 10px;
-  margin-left: 5px;
 }
 
 @media screen and (min-width: 768px) {
   .navbar, #hexlogo {
-    height: 40px;
+    height: 30px;
   }
   .navbar .navbar-brand {
     line-height: 19px;

--- a/inst/pkgdown/templates/navbar.html
+++ b/inst/pkgdown/templates/navbar.html
@@ -10,7 +10,7 @@
       </button>
 
       <div class="navbar-brand-container">
-        <a href="https://ropensci.org"><img src="https://ropensci.org/android-chrome-512x512.png" id="hexlogo" alt="rOpenSci" /></a>
+        <a href="https://ropensci.org"><img src="https://ropensci.org/img/icon_short_white.svg" id="hexlogo" alt="rOpenSci" /></a>
         <a class="navbar-brand" href="{{#site}}{{root}}{{/site}}index.html"><i>{{#package}}{{name}}{{/package}} <small>v{{#package}}{{version}}{{/package}}</small></i></a>
       </div>
     </div>


### PR DESCRIPTION
Reuse svg file already present in the footer in the navbar:

- more efficient (one less request)
- solve the issue where the hue is slightly different between the img file and the navbar itself

I tested locally and it works fine