### PR TITLE
fix: align font size for navbar items

### DIFF
--- a/inst/pkgdown/extra.scss
+++ b/inst/pkgdown/extra.scss
@@ -7,7 +7,7 @@
   min-height: 40px;
 }
 
-.navbar a.nav-link {
+.navbar .nav-link {
 	font-size: 1.2rem;
 }
 


### PR DESCRIPTION
Fix #116